### PR TITLE
fix(ci): repair Renovate config validation and restore GitHub Actions…

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,7 +21,6 @@
     {
       "description": "GitHub Actions",
       "matchManagers": ["github-actions"],
-      "matchUpdateTypes": ["major", "minor", "patch"],
       "rangeStrategy": "pin",
       "automerge": true,
       "labels": ["github-actions", "dependencies"]
@@ -41,6 +40,7 @@
     },
     {
       "matchUpdateTypes": ["major"],
+      "excludePackagePatterns": ["^actions/"],
       "dependencyDashboardApproval": true
     }
   ],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,30 +53,3 @@ jobs:
         with:
           version: latest
           args: --timeout=5m
-
-  renovate-config:
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
-        with:
-          fetch-depth: 0
-
-      - name: Check if renovate.json was modified
-        id: check-renovate
-        run: |
-          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q ".github/renovate.json"; then
-            echo "renovate_modified=true" >> $GITHUB_OUTPUT
-          else
-            echo "renovate_modified=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Validate Renovate config
-        if: steps.check-renovate.outputs.renovate_modified == 'true'
-        uses: renovatebot/github-action@21d88b0bf0183abcee15f990011cca090dfc47dd # v40.1.12
-        with:
-          configurationFile: .github/renovate.json
-          token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          RENOVATE_CONFIG_VALIDATION: true
-          LOG_LEVEL: debug

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -3,8 +3,6 @@ name: Conventional Commits
 on:
   pull_request:
     types: [opened, edited, synchronize]
-  pull_request_target:
-    types: [opened, edited, synchronize]
 
 permissions:
   contents: read

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -1,0 +1,17 @@
+name: Validate Renovate Config
+
+on:
+  pull_request:
+    paths:
+      - ".github/renovate.json"
+      - ".github/renovate-global.js"
+
+jobs:
+  renovate-config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+
+      - name: Validate Renovate config
+        run: |
+          npx --yes --package renovate -- renovate-config-validator .github/renovate.json


### PR DESCRIPTION
… major automerge

- Remove conflicting matchUpdateTypes from GitHub Actions rule that caused validation errors
- Replace broken renovate validation in CI with dedicated validator that fails on errors
- Exclude GitHub Actions from global major update approval requirement to restore automerge